### PR TITLE
Add overview output

### DIFF
--- a/main.py
+++ b/main.py
@@ -4,6 +4,8 @@ import logging
 import os
 import subprocess
 import sys
+from datetime import date
+from utils.output_writer import OutputWriter
 
 sys.path.append(os.path.abspath(os.path.dirname(__file__)))
 
@@ -38,6 +40,13 @@ def main(args):
         folder_name = Path(f"{DirectoryPaths.OUTPUTS.value}/{data['test_name']}")
         folder_name.mkdir(parents=True, exist_ok=True)
         print(f"Created output directory for test: {data['test_name']}")
+
+        overview_file_path = f"{DirectoryPaths.OUTPUTS.value}/{data['test_name']}/overview.txt"
+        writer = OutputWriter(overview_file_path)
+        writer(f"Test '{data['test_name']}' on {date.today()}")
+        writer(f"--------------------------------------------")
+
+        print(f"Test '{data['test_name']}' on {date.today()}")
 
         if Solvers.DOWHY.value in data["solvers"]:
             run_task(

--- a/utils/output_writer.py
+++ b/utils/output_writer.py
@@ -26,7 +26,7 @@ class OutputWriter:
     """
 
 
-    def __init__(self, output_path=f"{DirectoryPaths.OUTPUTS.value}/DEFAULT_OUTPUT.txt"):
+    def __init__(self, output_path=f"{DirectoryPaths.OUTPUTS.value}/DEFAULT_OUTPUT.txt", reset: bool = True):
         """
         Initialize the OutputWriter with the given output path.
 
@@ -35,7 +35,8 @@ class OutputWriter:
         """
         
         self.output_path = output_path
-        self.reset()
+        if reset:
+            self.reset()
 
 
     def __call__(self, output, new=False):


### PR DESCRIPTION
Adiciona o cálculo do tempo de execução de cada solver
Criar arquivo "overview.txt" que contém o tempo de cada solver e o ATE retornado.