### PR TITLE
Small change in the log_error_function

### DIFF
--- a/utils/general_utilities.py
+++ b/utils/general_utilities.py
@@ -97,7 +97,8 @@ def log_solver_error(e, solver_name: str, test_name: str):
         f"{DirectoryPaths.OUTPUTS.value}/{test_name}/"
         f"{solver_name}_{test_name}.txt"
     )
-    solver_writer = OutputWriter(output_file)
+    solver_writer = OutputWriter(output_file, reset=False)
+    solver_writer("=============================================")
     solver_writer(msg)
 
     overview_file_path = (


### PR DESCRIPTION
Changed it so that when the execution of a solver goes wrong, we get the error message at the end of its output, instead of overwriting it. That way we can check where the solver was and what it was doing before the error was given.