### PR TITLE
UAI write fix

### DIFF
--- a/utils/file_generators/uai_generator.py
+++ b/utils/file_generators/uai_generator.py
@@ -260,7 +260,9 @@ class UAIGenerator:
             for node in nodes:
                 mechanism = mechanisms[node]
                 uai.write(
-                    f"{len(mechanism)}   {' '.join(map(str, mechanism))}\n")
+                    f"{len(mechanism)}   {' '.join(f'{val:.15f}'.rstrip('0').rstrip('.') if isinstance(val, float) else str(val) for val in mechanism)}\n"
+                )
+
 
     def get_mapping_str(self) -> str:
         """


### PR DESCRIPTION
Modified the `write_uai_file` method to format floating-point numbers with up to 15 decimal places, removing trailing zeros and the decimal point if unnecessary. 

Before the changes, it would write sufficiently small numbers using scientific notation, which generated errors when Bcause would try to read them.